### PR TITLE
The default should be rockylinux8.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY : all clean
 SHELL:=/usr/bin/env bash
-CONT_NAME ?= rockylinux
+CONT_NAME ?= rockylinux8
 
 # Usage: $ make [CONT_NAME=<rockylinux8|ubuntu20.04|etc>] [clean]
 


### PR DESCRIPTION
Otherwise, this raises an error, because `rockylinux` by itself is not defined.